### PR TITLE
Fix the number of arguments of the reviewer_did_answer_card hook

### DIFF
--- a/src/review_feedback/reviewer.py
+++ b/src/review_feedback/reviewer.py
@@ -31,6 +31,7 @@
 
 from pathlib import Path
 
+from anki.cards import Card
 from anki.hooks import wrap
 from aqt.reviewer import Reviewer
 from aqt.utils import showWarning
@@ -65,7 +66,7 @@ def _getImagePaths(set_name: str) -> Optional[MediaPaths]:
     return None
 
 
-def onAnswerCard(reviewer: Reviewer, ease: int):
+def onAnswerCard(reviewer: Reviewer, card: Card, ease: int):
     image_set = config["local"]["imageSet"]
     duration = config["local"]["feedbackDuration"]
 


### PR DESCRIPTION
#### Description
Fixes this error:
```
Caught exception:
Traceback (most recent call last):
  File "/home/zjosua/sw_dev/anki/qt/aqt/webview.py", line 30, in cmd
    return json.dumps(self.onCmd(str))
  File "/home/zjosua/sw_dev/anki/qt/aqt/webview.py", line 96, in _onCmd
    return self._onBridgeCmd(str)
  File "/home/zjosua/sw_dev/anki/qt/aqt/webview.py", line 422, in _onBridgeCmd
    return self.onBridgeCmd(cmd)
  File "/home/zjosua/sw_dev/anki/qt/aqt/reviewer.py", line 319, in _linkHandler
    self._answerCard(int(url[4:]))
  File "/home/zjosua/sw_dev/anki/qt/aqt/reviewer.py", line 251, in _answerCard
    gui_hooks.reviewer_did_answer_card(self, self.card, ease)
  File "/home/zjosua/sw_dev/anki/qt/aqt/gui_hooks.py", line 667, in __call__
    hook(reviewer, card, ease)
TypeError: onAnswerCard() takes 2 positional arguments but 3 were given
```

#### Checklist:

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [ ] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [x] Running Anki from source; Version 2.1.20 (ab1f2429)
  - [ ] Latest alternative Anki 2.1 binary build [optional, but very welcome for changes to PyQt GUI components]
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [ ] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian bullseye
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
