### PR TITLE
Round floats to avoid implicit conversion to int

### DIFF
--- a/src/review_feedback/feedback.py
+++ b/src/review_feedback/feedback.py
@@ -71,7 +71,8 @@ def confirm(image_path: str, period: int):
         Qt.ToolTip | Qt.FramelessWindowHint | Qt.NoDropShadowWindowHint  # type: ignore
     )
     center = parent.frameGeometry().center()
-    qp = QPoint(img.width() * 0.5, img.height() * 0.5)  # type: ignore
+    qp = QPoint(round(img.width() * 0.5),
+                round(img.height() * 0.5))  # type: ignore
     lab.move(center - qp)
     lab.show()
     _timer = mw.progress.timer(period, closeConfirm, False)


### PR DESCRIPTION
#### Description

See title.
`Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.`

#### Checklist:

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [x] Anki 2.1 running from source (414ff5db1)
  - [ ] Latest alternative Anki 2.1 binary build [optional, but very welcome for changes to PyQt GUI components]
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian bullseye
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
