### PR TITLE
Add PyQt6 imports

### DIFF
--- a/src/review_feedback/feedback.py
+++ b/src/review_feedback/feedback.py
@@ -33,13 +33,19 @@
 Visual feedback
 """
 
-from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import QLabel
-from PyQt5.QtCore import QPoint, Qt, QTimer
+from typing import TYPE_CHECKING, Optional
 
 from aqt import mw
+from aqt.qt import qtmajor
 
-from typing import Optional
+if TYPE_CHECKING or qtmajor >= 6:
+    from PyQt6.QtGui import QImage, QPixmap
+    from PyQt6.QtWidgets import QLabel
+    from PyQt6.QtCore import QPoint, Qt, QTimer
+else:
+    from PyQt5.QtGui import QImage, QPixmap
+    from PyQt5.QtWidgets import QLabel
+    from PyQt5.QtCore import QPoint, Qt, QTimer
 
 _lab: Optional[QLabel] = None
 _timer: Optional[QTimer] = None

--- a/src/review_feedback/libaddon/config/signals.py
+++ b/src/review_feedback/libaddon/config/signals.py
@@ -29,7 +29,14 @@
 #
 # Any modifications to this file must keep this entire header intact.
 
-from PyQt5.QtCore import pyqtSignal, QObject
+from typing import TYPE_CHECKING
+
+from aqt.qt import qtmajor
+
+if TYPE_CHECKING or qtmajor >= 6:
+    from PyQt6.QtCore import QObject, pyqtSignal
+else:
+    from PyQt5.QtCore import QObject, pyqtSignal
 
 
 class ConfigSignals(QObject):


### PR DESCRIPTION
#### Description

Add PyQt6 imports.

#### Checklist:

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build [optional, but very welcome for changes to PyQt GUI components]
  - [x]  Anki Version ⁨23.10 (23823d31)⁩ running from source
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian 12
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
